### PR TITLE
Fixed activity tracing with a name that contains XML predefined characters.

### DIFF
--- a/Tracer.SystemDiagnostics/content/net35/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs
+++ b/Tracer.SystemDiagnostics/content/net35/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs
@@ -110,6 +110,9 @@ namespace Tracing.SystemDiagnostics
 
             class ActivityData : XPathNavigator
             {
+                static readonly XNamespace TraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord");
+                static readonly XNamespace DictionaryTraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2006/08/ServiceModel/DictionaryTraceRecord");
+
                 string displayName;
                 XPathNavigator xml;
 
@@ -119,16 +122,19 @@ namespace Tracing.SystemDiagnostics
 
                     // The particular XML format expected by the Service Trace Viewer was 
                     // inferred from the actual tool behavior and usage.
-                    this.xml = XDocument.Parse(string.Format(@"
-        <TraceRecord xmlns='http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord' Severity='{0}'>
-            <TraceIdentifier>http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx</TraceIdentifier>
-            <Description>Activity boundary.</Description>
-            <AppDomain>client.vshost.exe</AppDomain>
-            <ExtendedData xmlns='http://schemas.microsoft.com/2006/08/ServiceModel/DictionaryTraceRecord'>
-                <ActivityName>{1}</ActivityName>
-                <ActivityType>ActivityTracing</ActivityType>
-            </ExtendedData>
-        </TraceRecord>", isStart ? "Start" : "Stop", displayName)).CreateNavigator();
+                    this.xml = (new XDocument(
+                        new XElement(TraceRecordNamespace + "TraceRecord",
+                            new XAttribute("xmlns", TraceRecordNamespace),
+                            new XAttribute("Severity", isStart ? "Start" : "Stop"),
+                            new XElement(TraceRecordNamespace + "TraceIdentifier", "http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx"),
+                            new XElement(TraceRecordNamespace + "Description", "Activity boundary."),
+                            new XElement(TraceRecordNamespace + "AppDomain", "client.vshost.exe"),
+                            new XElement(DictionaryTraceRecordNamespace + "ExtendedData",
+                                new XElement(DictionaryTraceRecordNamespace + "ActivityName", displayName),
+                                new XElement(DictionaryTraceRecordNamespace + "ActivityType", "ActivityTracing")
+                            )
+                        )
+                    )).CreateNavigator();
                 }
 
                 public override string BaseURI

--- a/Tracer.SystemDiagnostics/content/net35/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs
+++ b/Tracer.SystemDiagnostics/content/net35/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs
@@ -112,6 +112,13 @@ namespace Tracing.SystemDiagnostics
             {
                 static readonly XNamespace TraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord");
                 static readonly XNamespace DictionaryTraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2006/08/ServiceModel/DictionaryTraceRecord");
+                static readonly XName TraceRecord = TraceRecordNamespace + "TraceRecord";
+                static readonly XName TraceIdentifier = TraceRecordNamespace + "TraceIdentifier";
+                static readonly XName Description = TraceRecordNamespace + "Description";
+                static readonly XName AppDomain = TraceRecordNamespace + "AppDomain";
+                static readonly XName ExtendedData = DictionaryTraceRecordNamespace + "ExtendedData";
+                static readonly XName ActivityName = DictionaryTraceRecordNamespace + "ActivityName";
+                static readonly XName ActivityType = DictionaryTraceRecordNamespace + "ActivityType";
 
                 string displayName;
                 XPathNavigator xml;
@@ -123,15 +130,15 @@ namespace Tracing.SystemDiagnostics
                     // The particular XML format expected by the Service Trace Viewer was 
                     // inferred from the actual tool behavior and usage.
                     this.xml = (new XDocument(
-                        new XElement(TraceRecordNamespace + "TraceRecord",
+                        new XElement(TraceRecord,
                             new XAttribute("xmlns", TraceRecordNamespace),
                             new XAttribute("Severity", isStart ? "Start" : "Stop"),
-                            new XElement(TraceRecordNamespace + "TraceIdentifier", "http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx"),
-                            new XElement(TraceRecordNamespace + "Description", "Activity boundary."),
-                            new XElement(TraceRecordNamespace + "AppDomain", "client.vshost.exe"),
-                            new XElement(DictionaryTraceRecordNamespace + "ExtendedData",
-                                new XElement(DictionaryTraceRecordNamespace + "ActivityName", displayName),
-                                new XElement(DictionaryTraceRecordNamespace + "ActivityType", "ActivityTracing")
+                            new XElement(TraceIdentifier, "http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx"),
+                            new XElement(Description, "Activity boundary."),
+                            new XElement(AppDomain, "client.vshost.exe"),
+                            new XElement(ExtendedData,
+                                new XElement(ActivityName, displayName),
+                                new XElement(ActivityType, "ActivityTracing")
                             )
                         )
                     )).CreateNavigator();

--- a/Tracer.SystemDiagnostics/content/net35/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs.pp
+++ b/Tracer.SystemDiagnostics/content/net35/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs.pp
@@ -112,6 +112,13 @@ namespace $rootnamespace$.Diagnostics
             {
                 static readonly XNamespace TraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord");
                 static readonly XNamespace DictionaryTraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2006/08/ServiceModel/DictionaryTraceRecord");
+                static readonly XName TraceRecord = TraceRecordNamespace + "TraceRecord";
+                static readonly XName TraceIdentifier = TraceRecordNamespace + "TraceIdentifier";
+                static readonly XName Description = TraceRecordNamespace + "Description";
+                static readonly XName AppDomain = TraceRecordNamespace + "AppDomain";
+                static readonly XName ExtendedData = DictionaryTraceRecordNamespace + "ExtendedData";
+                static readonly XName ActivityName = DictionaryTraceRecordNamespace + "ActivityName";
+                static readonly XName ActivityType = DictionaryTraceRecordNamespace + "ActivityType";
 
                 string displayName;
                 XPathNavigator xml;
@@ -123,15 +130,15 @@ namespace $rootnamespace$.Diagnostics
                     // The particular XML format expected by the Service Trace Viewer was 
                     // inferred from the actual tool behavior and usage.
                     this.xml = (new XDocument(
-                        new XElement(TraceRecordNamespace + "TraceRecord",
+                        new XElement(TraceRecord,
                             new XAttribute("xmlns", TraceRecordNamespace),
                             new XAttribute("Severity", isStart ? "Start" : "Stop"),
-                            new XElement(TraceRecordNamespace + "TraceIdentifier", "http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx"),
-                            new XElement(TraceRecordNamespace + "Description", "Activity boundary."),
-                            new XElement(TraceRecordNamespace + "AppDomain", "client.vshost.exe"),
-                            new XElement(DictionaryTraceRecordNamespace + "ExtendedData",
-                                new XElement(DictionaryTraceRecordNamespace + "ActivityName", displayName),
-                                new XElement(DictionaryTraceRecordNamespace + "ActivityType", "ActivityTracing")
+                            new XElement(TraceIdentifier, "http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx"),
+                            new XElement(Description, "Activity boundary."),
+                            new XElement(AppDomain, "client.vshost.exe"),
+                            new XElement(ExtendedData,
+                                new XElement(ActivityName, displayName),
+                                new XElement(ActivityType, "ActivityTracing")
                             )
                         )
                     )).CreateNavigator();

--- a/Tracer.SystemDiagnostics/content/net35/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs.pp
+++ b/Tracer.SystemDiagnostics/content/net35/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs.pp
@@ -110,6 +110,9 @@ namespace $rootnamespace$.Diagnostics
 
             class ActivityData : XPathNavigator
             {
+                static readonly XNamespace TraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord");
+                static readonly XNamespace DictionaryTraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2006/08/ServiceModel/DictionaryTraceRecord");
+
                 string displayName;
                 XPathNavigator xml;
 
@@ -119,16 +122,19 @@ namespace $rootnamespace$.Diagnostics
 
                     // The particular XML format expected by the Service Trace Viewer was 
                     // inferred from the actual tool behavior and usage.
-                    this.xml = XDocument.Parse(string.Format(@"
-        <TraceRecord xmlns='http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord' Severity='{0}'>
-            <TraceIdentifier>http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx</TraceIdentifier>
-            <Description>Activity boundary.</Description>
-            <AppDomain>client.vshost.exe</AppDomain>
-            <ExtendedData xmlns='http://schemas.microsoft.com/2006/08/ServiceModel/DictionaryTraceRecord'>
-                <ActivityName>{1}</ActivityName>
-                <ActivityType>ActivityTracing</ActivityType>
-            </ExtendedData>
-        </TraceRecord>", isStart ? "Start" : "Stop", displayName)).CreateNavigator();
+                    this.xml = (new XDocument(
+                        new XElement(TraceRecordNamespace + "TraceRecord",
+                            new XAttribute("xmlns", TraceRecordNamespace),
+                            new XAttribute("Severity", isStart ? "Start" : "Stop"),
+                            new XElement(TraceRecordNamespace + "TraceIdentifier", "http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx"),
+                            new XElement(TraceRecordNamespace + "Description", "Activity boundary."),
+                            new XElement(TraceRecordNamespace + "AppDomain", "client.vshost.exe"),
+                            new XElement(DictionaryTraceRecordNamespace + "ExtendedData",
+                                new XElement(DictionaryTraceRecordNamespace + "ActivityName", displayName),
+                                new XElement(DictionaryTraceRecordNamespace + "ActivityType", "ActivityTracing")
+                            )
+                        )
+                    )).CreateNavigator();
                 }
 
                 public override string BaseURI

--- a/Tracer.SystemDiagnostics/content/net40/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs
+++ b/Tracer.SystemDiagnostics/content/net40/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs
@@ -110,6 +110,9 @@ namespace Tracing.SystemDiagnostics
 
             class ActivityData : XPathNavigator
             {
+                static readonly XNamespace TraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord");
+                static readonly XNamespace DictionaryTraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2006/08/ServiceModel/DictionaryTraceRecord");
+
                 string displayName;
                 XPathNavigator xml;
 
@@ -119,16 +122,19 @@ namespace Tracing.SystemDiagnostics
 
                     // The particular XML format expected by the Service Trace Viewer was 
                     // inferred from the actual tool behavior and usage.
-                    this.xml = XDocument.Parse(string.Format(@"
-        <TraceRecord xmlns='http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord' Severity='{0}'>
-            <TraceIdentifier>http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx</TraceIdentifier>
-            <Description>Activity boundary.</Description>
-            <AppDomain>client.vshost.exe</AppDomain>
-            <ExtendedData xmlns='http://schemas.microsoft.com/2006/08/ServiceModel/DictionaryTraceRecord'>
-                <ActivityName>{1}</ActivityName>
-                <ActivityType>ActivityTracing</ActivityType>
-            </ExtendedData>
-        </TraceRecord>", isStart ? "Start" : "Stop", displayName)).CreateNavigator();
+                    this.xml = (new XDocument(
+                        new XElement(TraceRecordNamespace + "TraceRecord",
+                            new XAttribute("xmlns", TraceRecordNamespace),
+                            new XAttribute("Severity", isStart ? "Start" : "Stop"),
+                            new XElement(TraceRecordNamespace + "TraceIdentifier", "http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx"),
+                            new XElement(TraceRecordNamespace + "Description", "Activity boundary."),
+                            new XElement(TraceRecordNamespace + "AppDomain", "client.vshost.exe"),
+                            new XElement(DictionaryTraceRecordNamespace + "ExtendedData",
+                                new XElement(DictionaryTraceRecordNamespace + "ActivityName", displayName),
+                                new XElement(DictionaryTraceRecordNamespace + "ActivityType", "ActivityTracing")
+                            )
+                        )
+                    )).CreateNavigator();
                 }
 
                 public override string BaseURI

--- a/Tracer.SystemDiagnostics/content/net40/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs
+++ b/Tracer.SystemDiagnostics/content/net40/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs
@@ -112,6 +112,13 @@ namespace Tracing.SystemDiagnostics
             {
                 static readonly XNamespace TraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord");
                 static readonly XNamespace DictionaryTraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2006/08/ServiceModel/DictionaryTraceRecord");
+                static readonly XName TraceRecord = TraceRecordNamespace + "TraceRecord";
+                static readonly XName TraceIdentifier = TraceRecordNamespace + "TraceIdentifier";
+                static readonly XName Description = TraceRecordNamespace + "Description";
+                static readonly XName AppDomain = TraceRecordNamespace + "AppDomain";
+                static readonly XName ExtendedData = DictionaryTraceRecordNamespace + "ExtendedData";
+                static readonly XName ActivityName = DictionaryTraceRecordNamespace + "ActivityName";
+                static readonly XName ActivityType = DictionaryTraceRecordNamespace + "ActivityType";
 
                 string displayName;
                 XPathNavigator xml;
@@ -123,15 +130,15 @@ namespace Tracing.SystemDiagnostics
                     // The particular XML format expected by the Service Trace Viewer was 
                     // inferred from the actual tool behavior and usage.
                     this.xml = (new XDocument(
-                        new XElement(TraceRecordNamespace + "TraceRecord",
+                        new XElement(TraceRecord,
                             new XAttribute("xmlns", TraceRecordNamespace),
                             new XAttribute("Severity", isStart ? "Start" : "Stop"),
-                            new XElement(TraceRecordNamespace + "TraceIdentifier", "http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx"),
-                            new XElement(TraceRecordNamespace + "Description", "Activity boundary."),
-                            new XElement(TraceRecordNamespace + "AppDomain", "client.vshost.exe"),
-                            new XElement(DictionaryTraceRecordNamespace + "ExtendedData",
-                                new XElement(DictionaryTraceRecordNamespace + "ActivityName", displayName),
-                                new XElement(DictionaryTraceRecordNamespace + "ActivityType", "ActivityTracing")
+                            new XElement(TraceIdentifier, "http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx"),
+                            new XElement(Description, "Activity boundary."),
+                            new XElement(AppDomain, "client.vshost.exe"),
+                            new XElement(ExtendedData,
+                                new XElement(ActivityName, displayName),
+                                new XElement(ActivityType, "ActivityTracing")
                             )
                         )
                     )).CreateNavigator();

--- a/Tracer.SystemDiagnostics/content/net40/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs.pp
+++ b/Tracer.SystemDiagnostics/content/net40/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs.pp
@@ -112,6 +112,13 @@ namespace $rootnamespace$.Diagnostics
             {
                 static readonly XNamespace TraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord");
                 static readonly XNamespace DictionaryTraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2006/08/ServiceModel/DictionaryTraceRecord");
+                static readonly XName TraceRecord = TraceRecordNamespace + "TraceRecord";
+                static readonly XName TraceIdentifier = TraceRecordNamespace + "TraceIdentifier";
+                static readonly XName Description = TraceRecordNamespace + "Description";
+                static readonly XName AppDomain = TraceRecordNamespace + "AppDomain";
+                static readonly XName ExtendedData = DictionaryTraceRecordNamespace + "ExtendedData";
+                static readonly XName ActivityName = DictionaryTraceRecordNamespace + "ActivityName";
+                static readonly XName ActivityType = DictionaryTraceRecordNamespace + "ActivityType";
 
                 string displayName;
                 XPathNavigator xml;
@@ -123,15 +130,15 @@ namespace $rootnamespace$.Diagnostics
                     // The particular XML format expected by the Service Trace Viewer was 
                     // inferred from the actual tool behavior and usage.
                     this.xml = (new XDocument(
-                        new XElement(TraceRecordNamespace + "TraceRecord",
+                        new XElement(TraceRecord,
                             new XAttribute("xmlns", TraceRecordNamespace),
                             new XAttribute("Severity", isStart ? "Start" : "Stop"),
-                            new XElement(TraceRecordNamespace + "TraceIdentifier", "http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx"),
-                            new XElement(TraceRecordNamespace + "Description", "Activity boundary."),
-                            new XElement(TraceRecordNamespace + "AppDomain", "client.vshost.exe"),
-                            new XElement(DictionaryTraceRecordNamespace + "ExtendedData",
-                                new XElement(DictionaryTraceRecordNamespace + "ActivityName", displayName),
-                                new XElement(DictionaryTraceRecordNamespace + "ActivityType", "ActivityTracing")
+                            new XElement(TraceIdentifier, "http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx"),
+                            new XElement(Description, "Activity boundary."),
+                            new XElement(AppDomain, "client.vshost.exe"),
+                            new XElement(ExtendedData,
+                                new XElement(ActivityName, displayName),
+                                new XElement(ActivityType, "ActivityTracing")
                             )
                         )
                     )).CreateNavigator();

--- a/Tracer.SystemDiagnostics/content/net40/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs.pp
+++ b/Tracer.SystemDiagnostics/content/net40/External/Diagnostics/Tracer/SystemDiagnostics/StartActivityExtension.cs.pp
@@ -110,6 +110,9 @@ namespace $rootnamespace$.Diagnostics
 
             class ActivityData : XPathNavigator
             {
+                static readonly XNamespace TraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord");
+                static readonly XNamespace DictionaryTraceRecordNamespace = XNamespace.Get("http://schemas.microsoft.com/2006/08/ServiceModel/DictionaryTraceRecord");
+
                 string displayName;
                 XPathNavigator xml;
 
@@ -119,16 +122,19 @@ namespace $rootnamespace$.Diagnostics
 
                     // The particular XML format expected by the Service Trace Viewer was 
                     // inferred from the actual tool behavior and usage.
-                    this.xml = XDocument.Parse(string.Format(@"
-        <TraceRecord xmlns='http://schemas.microsoft.com/2004/10/E2ETraceEvent/TraceRecord' Severity='{0}'>
-            <TraceIdentifier>http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx</TraceIdentifier>
-            <Description>Activity boundary.</Description>
-            <AppDomain>client.vshost.exe</AppDomain>
-            <ExtendedData xmlns='http://schemas.microsoft.com/2006/08/ServiceModel/DictionaryTraceRecord'>
-                <ActivityName>{1}</ActivityName>
-                <ActivityType>ActivityTracing</ActivityType>
-            </ExtendedData>
-        </TraceRecord>", isStart ? "Start" : "Stop", displayName)).CreateNavigator();
+                    this.xml = (new XDocument(
+                        new XElement(TraceRecordNamespace + "TraceRecord",
+                            new XAttribute("xmlns", TraceRecordNamespace),
+                            new XAttribute("Severity", isStart ? "Start" : "Stop"),
+                            new XElement(TraceRecordNamespace + "TraceIdentifier", "http://msdn.microsoft.com/en-US/library/System.ServiceModel.Diagnostics.ActivityBoundary.aspx"),
+                            new XElement(TraceRecordNamespace + "Description", "Activity boundary."),
+                            new XElement(TraceRecordNamespace + "AppDomain", "client.vshost.exe"),
+                            new XElement(DictionaryTraceRecordNamespace + "ExtendedData",
+                                new XElement(DictionaryTraceRecordNamespace + "ActivityName", displayName),
+                                new XElement(DictionaryTraceRecordNamespace + "ActivityType", "ActivityTracing")
+                            )
+                        )
+                    )).CreateNavigator();
                 }
 
                 public override string BaseURI

--- a/Tracer.UnitTests/DiagnosticsTracerSpec.cs
+++ b/Tracer.UnitTests/DiagnosticsTracerSpec.cs
@@ -110,5 +110,18 @@ namespace Tracing
 
             Console.WriteLine(writer.ToString());
         }
+
+        [Fact]
+        public void when_tracing_activity_with_predefined_entity_in_name_then_succeeds()
+        {
+            var listener = new Mock<TraceListener>();
+            manager.AddListener("Foo", listener.Object);
+
+            manager.SetTracingLevel("Foo", SourceLevels.Information);
+
+            var tracer = Tracer.Get("Foo");
+
+            tracer.StartActivity("&");
+        }
     }
 }


### PR DESCRIPTION
Activity tracing with a name that contains XML predefined characters like '&' cause an `XmlException` to be thrown. This fixes it by escaping necessary entities.
